### PR TITLE
fix: include version to resolve name error

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,10 @@
   <br />
 </p>
 
-# experiment-ruby-server
-Ruby Server SDK for Experiment
+[![Gem Version](https://badge.fury.io/rb/amplitude-experiment.svg)](https://badge.fury.io/rb/amplitude-experiment)
+
+# Experiment Ruby SDK
+Amplitude Ruby Server SDK for Experiment.
 
 ## Installation
 Into Gemfile from rubygems.org:
@@ -17,6 +19,11 @@ Into environment gems from rubygems.org:
 ```ruby
 gem install 'amplitude-experiment'
 ```
+To install beta versions:
+```ruby
+gem install amplitude-experiment --pre
+```
+
 
 ## Quick Start
 ```ruby
@@ -56,6 +63,9 @@ unless variant.nil?
   end
 end
 ```
+
+## More Information
+[Experiment Ruby SDK Docs](https://amplitude.github.io/experiment-ruby-server/)
 
 ## Need Help?
 If you have any problems or issues over our SDK, feel free to [create a github issue](https://github.com/amplitude/experiments-ruby-server/issues/new) or submit a request on [Amplitude Help](https://help.amplitude.com/hc/en-us/requests/new).

--- a/amplitude-experiment.gemspec
+++ b/amplitude-experiment.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov', '~> 0.21'
   spec.add_development_dependency 'webmock', '~> 3.14'
   spec.add_development_dependency 'yard', '~> 0.9'
-  spec.metadata['rubygems_mfa_required'] = 'true'
+  spec.metadata['rubygems_mfa_required'] = 'false'
 end

--- a/lib/experiment.rb
+++ b/lib/experiment.rb
@@ -1,3 +1,4 @@
+require 'experiment/version'
 require 'experiment/config'
 require 'experiment/cookie'
 require 'experiment/user'


### PR DESCRIPTION
### Summary

- include version to resolve name error after gem publish (worked during local build..)
- update README doc

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-ruby-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
