### PR TITLE
fix: Include libevaluation_interp libraries in gem

### DIFF
--- a/amplitude-experiment.gemspec
+++ b/amplitude-experiment.gemspec
@@ -14,7 +14,9 @@ Gem::Specification.new do |spec|
   spec.files                 = Dir['README.md',
                                    'lib/**/*.rb',
                                    'experiment-ruby.gemspec',
-                                   'Gemfile']
+                                   'Gemfile',
+                                   'lib/experiment/local/evaluation/lib/**/*.so',
+                                   'lib/experiment/local/evaluation/lib/**/*.dylib']
   spec.require_paths         = ["lib"]
   spec.extra_rdoc_files      = ['README.md']
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Experiment Ruby Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
Include the necessary .so and .dylib files.  This fixes the bug where installing the latest version of the gem results in a `LoadError` due to the file not being found.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-ruby-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?: No  <!-- Yes or no --> 
