### PR TITLE
fix: use response.code instead of response.status when logging error

### DIFF
--- a/lib/experiment/local/fetcher.rb
+++ b/lib/experiment/local/fetcher.rb
@@ -24,7 +24,7 @@ module AmplitudeExperiment
       }
       request = Net::HTTP::Get.new(@uri, headers)
       response = @http.request(request)
-      raise `flagConfigs - received error response: #{response.status}: #{response.body}` unless response.is_a?(Net::HTTPOK)
+      raise `flagConfigs - received error response: #{response.code}: #{response.body}` unless response.is_a?(Net::HTTPOK)
 
       flag_configs = parse(response.body)
       @logger.debug("[Experiment] Fetch flag configs: #{request.body}") if @debug


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Experiment Ruby Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
When logging an error for a failed fetch, use the `#code` method instead of `#status` ([documentation](https://ruby-doc.org/stdlib-3.1.2/libdoc/net/http/rdoc/Net/HTTPResponse.html))

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-ruby-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No! <!-- Yes or no -->
