### PR TITLE
fix: Use correct format for string interpolation

### DIFF
--- a/lib/experiment/local/client.rb
+++ b/lib/experiment/local/client.rb
@@ -44,7 +44,7 @@ module AmplitudeExperiment
       user_str = user.to_json
       @logger.debug("[Experiment] Evaluate: User: #{user_str} - Rules: #{flag_configs_str}") if @config.debug
       result_json = evaluation(flag_configs_str, user_str)
-      @logger.debug(`[Experiment] evaluate - result: #{variants}`) if @config.debug
+      @logger.debug("[Experiment] evaluate - result: #{variants}") if @config.debug
       result = JSON.parse(result_json)
       variants = {}
       result.each do |key, value|

--- a/lib/experiment/local/fetcher.rb
+++ b/lib/experiment/local/fetcher.rb
@@ -25,7 +25,7 @@ module AmplitudeExperiment
       }
       request = Net::HTTP::Get.new(@uri, headers)
       response = @http.request(request)
-      raise `flagConfigs - received error response: #{response.code}: #{response.body}` unless response.is_a?(Net::HTTPOK)
+      raise "flagConfigs - received error response: #{response.code}: #{response.body}" unless response.is_a?(Net::HTTPOK)
 
       flag_configs = parse(response.body)
       @logger.debug("[Experiment] Fetch flag configs: #{request.body}") if @debug


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Experiment Ruby Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

For string interpolation, we need to use double quotes instead of backticks.

### Summary

<!-- What does the PR do? -->

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-ruby-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
