### PR TITLE
fix: add arch for Docker (linux) on M1 Mac

### DIFF
--- a/lib/experiment/local/evaluation/evaluation.rb
+++ b/lib/experiment/local/evaluation/evaluation.rb
@@ -10,7 +10,7 @@ module EvaluationInterop
   ffi_lib ["#{evaluation_dir}/lib/macosX64/libevaluation_interop.dylib"] if host_os =~ /darwin|mac os/ && cpu =~ /x86_64/
   ffi_lib ["#{evaluation_dir}/lib/macosArm64/libevaluation_interop.dylib"] if host_os =~ /darwin|mac os/ && cpu =~ /arm64/
   ffi_lib ["#{evaluation_dir}/lib/linuxX64/libevaluation_interop.so"] if host_os =~ /linux/ && cpu =~ /x86_64/
-  ffi_lib ["#{evaluation_dir}/lib/linuxArm64/libevaluation_interop.so"] if host_os =~ /linux/ && cpu =~ /arm64/
+  ffi_lib ["#{evaluation_dir}/lib/linuxArm64/libevaluation_interop.so"] if host_os =~ /linux/ && cpu =~ /arm64|aarch64/
 
   class Root < FFI::Struct
     layout :evaluate, callback([:string, :string], :pointer)


### PR DESCRIPTION
### Summary

Adds `aarch64` as a Linux cpu option when loading ffi libs in `EvaluationInterop` module.

### Background

The gem was causing ffi to throw an error when added to a Rails project that runs under Docker on an M1 Mac. This is because the cpu is reported as "aarch64" (instead of "arm64"). This change will allow it to load the correct ffi libs for both cpu architectures.

Stack trace from error:

```
! Unable to load application: LoadError: no library specified
/app/vendor/bundle/ruby/3.1.0/gems/ffi-1.15.5/lib/ffi/library.rb:174:in `ffi_libraries': no library specified (LoadError)
	from /app/vendor/bundle/ruby/3.1.0/gems/ffi-1.15.5/lib/ffi/library.rb:252:in `attach_function'
	from /app/vendor/bundle/ruby/3.1.0/gems/amplitude-experiment-1.0.0.beta.12/lib/experiment/local/evaluation/evaluation.rb:39:in `<module:EvaluationInterop>'
	from /app/vendor/bundle/ruby/3.1.0/gems/amplitude-experiment-1.0.0.beta.12/lib/experiment/local/evaluation/evaluation.rb:5:in `<top (required)>'
	from /app/vendor/bundle/ruby/3.1.0/gems/amplitude-experiment-1.0.0.beta.12/lib/experiment/local/client.rb:3:in `require'
	from /app/vendor/bundle/ruby/3.1.0/gems/amplitude-experiment-1.0.0.beta.12/lib/experiment/local/client.rb:3:in `<top (required)>'
	from /app/vendor/bundle/ruby/3.1.0/gems/amplitude-experiment-1.0.0.beta.12/lib/amplitude-experiment.rb:9:in `require'
	from /app/vendor/bundle/ruby/3.1.0/gems/amplitude-experiment-1.0.0.beta.12/lib/amplitude-experiment.rb:9:in `<top (required)>'
	from /usr/local/bundle/gems/bundler-2.3.26/lib/bundler/runtime.rb:60:in `require'
	from /usr/local/bundle/gems/bundler-2.3.26/lib/bundler/runtime.rb:60:in `block (2 levels) in require'
	from /usr/local/bundle/gems/bundler-2.3.26/lib/bundler/runtime.rb:55:in `each'
	from /usr/local/bundle/gems/bundler-2.3.26/lib/bundler/runtime.rb:55:in `block in require'
	from /usr/local/bundle/gems/bundler-2.3.26/lib/bundler/runtime.rb:44:in `each'
	from /usr/local/bundle/gems/bundler-2.3.26/lib/bundler/runtime.rb:44:in `require'
	from /usr/local/bundle/gems/bundler-2.3.26/lib/bundler.rb:186:in `require'
	from /app/config/application.rb:21:in `<top (required)>'
	from /app/config/environment.rb:4:in `require_relative'
	from /app/config/environment.rb:4:in `<top (required)>'
	from config.ru:5:in `require_relative'
	from config.ru:5:in `block in <main>'
	from /app/vendor/bundle/ruby/3.1.0/gems/rack-2.2.4/lib/rack/builder.rb:116:in `eval'
	from /app/vendor/bundle/ruby/3.1.0/gems/rack-2.2.4/lib/rack/builder.rb:116:in `new_from_string'
	from /app/vendor/bundle/ruby/3.1.0/gems/rack-2.2.4/lib/rack/builder.rb:105:in `load_file'
	from /app/vendor/bundle/ruby/3.1.0/gems/rack-2.2.4/lib/rack/builder.rb:66:in `parse_file'
	from /app/vendor/bundle/ruby/3.1.0/gems/puma-6.0.0/lib/puma/configuration.rb:364:in `load_rackup'
	from /app/vendor/bundle/ruby/3.1.0/gems/puma-6.0.0/lib/puma/configuration.rb:286:in `app'
	from /app/vendor/bundle/ruby/3.1.0/gems/puma-6.0.0/lib/puma/runner.rb:158:in `load_and_bind'
	from /app/vendor/bundle/ruby/3.1.0/gems/puma-6.0.0/lib/puma/single.rb:44:in `run'
	from /app/vendor/bundle/ruby/3.1.0/gems/puma-6.0.0/lib/puma/launcher.rb:186:in `run'
	from /app/vendor/bundle/ruby/3.1.0/gems/puma-6.0.0/lib/puma/cli.rb:75:in `run'
	from /app/vendor/bundle/ruby/3.1.0/gems/puma-6.0.0/bin/puma:10:in `<top (required)>'
	from bin/puma:31:in `load'
	from bin/puma:31:in `<main>'
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-ruby-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
