### PR TITLE
fix: late require native binaries so remote code does not load them

### DIFF
--- a/amplitude-experiment.gemspec
+++ b/amplitude-experiment.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
 
   spec.files                 = Dir['README.md',
                                    'lib/**/*.rb',
-                                   'experiment-ruby.gemspec',
+                                   'amplitude-experiment.gemspec',
                                    'Gemfile',
                                    'lib/experiment/local/evaluation/lib/**/*']
   spec.require_paths         = ["lib"]

--- a/lib/experiment/local/client.rb
+++ b/lib/experiment/local/client.rb
@@ -1,6 +1,5 @@
 require 'uri'
 require 'logger'
-require 'experiment/local/evaluation/evaluation'
 
 module AmplitudeExperiment
   # Main client for fetching variant data.
@@ -10,6 +9,7 @@ module AmplitudeExperiment
     # @param [String] api_key The environment API Key
     # @param [LocalEvaluationConfig] config The config object
     def initialize(api_key, config = nil)
+      require 'experiment/local/evaluation/evaluation'
       @api_key = api_key
       @config = config || LocalEvaluationConfig.new
       @cache = InMemoryFlagConfigCache.new(@config.bootstrap)


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Experiment Ruby Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->
late require native binaries so remote code does not load them (should fix #33)

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-ruby-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
