### PR TITLE
fix: support multiple instances keyed by api key

### DIFF
--- a/lib/experiment/factory.rb
+++ b/lib/experiment/factory.rb
@@ -9,9 +9,7 @@ module AmplitudeExperiment
   # @param [String] api_key The environment API Key
   # @param [Config] config Optional Config.
   def self.initialize_remote(api_key, config = nil)
-    unless @remote_instance.key?(api_key)
-      @remote_instance.store(api_key, RemoteEvaluationClient.new(api_key, config))
-    end
+    @remote_instance.store(api_key, RemoteEvaluationClient.new(api_key, config)) unless @remote_instance.key?(api_key)
     @remote_instance.fetch(api_key)
   end
 
@@ -22,9 +20,7 @@ module AmplitudeExperiment
   # @param [String] api_key The environment API Key
   # @param [Config] config Optional Config.
   def self.initialize_local(api_key, config = nil)
-    unless @local_instance.key?(api_key)
-      @local_instance.store(api_key, LocalEvaluationClient.new(api_key, config))
-    end
+    @local_instance.store(api_key, LocalEvaluationClient.new(api_key, config)) unless @local_instance.key?(api_key)
     @local_instance.fetch(api_key)
   end
 end

--- a/lib/experiment/factory.rb
+++ b/lib/experiment/factory.rb
@@ -2,7 +2,6 @@
 module AmplitudeExperiment
   @local_instance = {}
   @remote_instance = {}
-  @default_instance = '$default_instance'
 
   # Initializes a singleton Client. This method returns a default singleton instance, subsequent calls to
   #  init will return the initial instance regardless of input.
@@ -10,10 +9,10 @@ module AmplitudeExperiment
   # @param [String] api_key The environment API Key
   # @param [Config] config Optional Config.
   def self.initialize_remote(api_key, config = nil)
-    unless @local_instance.key?(@default_instance)
-      @local_instance.store(@default_instance, RemoteEvaluationClient.new(api_key, config))
+    unless @remote_instance.key?(api_key)
+      @remote_instance.store(api_key, RemoteEvaluationClient.new(api_key, config))
     end
-    @local_instance.fetch(@default_instance)
+    @remote_instance.fetch(api_key)
   end
 
   # Initializes a local evaluation Client. A local evaluation client can evaluate local flags or experiments for a
@@ -23,9 +22,9 @@ module AmplitudeExperiment
   # @param [String] api_key The environment API Key
   # @param [Config] config Optional Config.
   def self.initialize_local(api_key, config = nil)
-    unless @remote_instance.key?(@default_instance)
-      @remote_instance.store(@default_instance, LocalEvaluationClient.new(api_key, config))
+    unless @local_instance.key?(api_key)
+      @local_instance.store(api_key, LocalEvaluationClient.new(api_key, config))
     end
-    @remote_instance.fetch(@default_instance)
+    @local_instance.fetch(api_key)
   end
 end

--- a/spec/experiment/local/factory_spec.rb
+++ b/spec/experiment/local/factory_spec.rb
@@ -10,7 +10,7 @@ describe AmplitudeExperiment do
     end
     it 'test hold a different instance for different api keys' do
       client1 = AmplitudeExperiment.initialize_local(API_KEY)
-      client2 = AmplitudeExperiment.initialize_local("different-api-key")
+      client2 = AmplitudeExperiment.initialize_local('different-api-key')
       expect(client1).not_to equal client2
     end
   end

--- a/spec/experiment/local/factory_spec.rb
+++ b/spec/experiment/local/factory_spec.rb
@@ -8,5 +8,10 @@ describe AmplitudeExperiment do
       client2 = AmplitudeExperiment.initialize_local(API_KEY)
       expect(client1).to equal client2
     end
+    it 'test hold a different instance for different api keys' do
+      client1 = AmplitudeExperiment.initialize_local(API_KEY)
+      client2 = AmplitudeExperiment.initialize_local("different-api-key")
+      expect(client1).not_to equal client2
+    end
   end
 end

--- a/spec/experiment/remote/factory_spec.rb
+++ b/spec/experiment/remote/factory_spec.rb
@@ -10,7 +10,7 @@ describe AmplitudeExperiment do
     end
     it 'test hold a different instance for different api keys' do
       client1 = AmplitudeExperiment.initialize_remote(API_KEY)
-      client2 = AmplitudeExperiment.initialize_remote("different-api-key")
+      client2 = AmplitudeExperiment.initialize_remote('different-api-key')
       expect(client1).not_to equal client2
     end
   end

--- a/spec/experiment/remote/factory_spec.rb
+++ b/spec/experiment/remote/factory_spec.rb
@@ -8,5 +8,10 @@ describe AmplitudeExperiment do
       client2 = AmplitudeExperiment.initialize_remote(API_KEY)
       expect(client1).to equal client2
     end
+    it 'test hold a different instance for different api keys' do
+      client1 = AmplitudeExperiment.initialize_remote(API_KEY)
+      client2 = AmplitudeExperiment.initialize_remote("different-api-key")
+      expect(client1).not_to equal client2
+    end
   end
 end


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Experiment Ruby Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

Support multiple instances keyed by api key.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-ruby-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
