### PR TITLE
fix: use a separate connection per deployment

### DIFF
--- a/lib/experiment/local/fetcher.rb
+++ b/lib/experiment/local/fetcher.rb
@@ -9,7 +9,7 @@ module AmplitudeExperiment
       @api_key = api_key
       @server_url = server_url
       @logger = logger
-      @http = PersistentHttpClient.get(server_url, { read_timeout: FLAG_CONFIG_TIMEOUT })
+      @http = PersistentHttpClient.get(server_url, { read_timeout: FLAG_CONFIG_TIMEOUT }, @api_key)
     end
 
     # Fetch local evaluation mode flag configs from the Experiment API server.

--- a/lib/experiment/persistent_http_client.rb
+++ b/lib/experiment/persistent_http_client.rb
@@ -12,7 +12,7 @@ module AmplitudeExperiment
       # options: any options that Net::HTTP.new accepts
       # api_key: the deployment key for ensuring different deployments dont
       # share connections.
-      def get(url, options = {}, api_key)
+      def get(url, options, api_key)
         uri = url.is_a?(URI) ? url : URI(url)
         connection_manager.get_client(uri, options, api_key)
       end

--- a/lib/experiment/persistent_http_client.rb
+++ b/lib/experiment/persistent_http_client.rb
@@ -10,7 +10,7 @@ module AmplitudeExperiment
     class << self
       # url: URI / String
       # options: any options that Net::HTTP.new accepts
-      # api_key: the deployment key for ensuring different deployments dont
+      # api_key: the deployment key for ensuring different deployments don't
       # share connections.
       def get(url, options, api_key)
         uri = url.is_a?(URI) ? url : URI(url)

--- a/lib/experiment/remote/client.rb
+++ b/lib/experiment/remote/client.rb
@@ -99,7 +99,7 @@ module AmplitudeExperiment
         'Content-Type' => 'application/json;charset=utf-8'
       }
       read_timeout = timeout_millis / 1000 if (timeout_millis / 1000) > 0
-      http = PersistentHttpClient.get(@uri, { read_timeout: read_timeout })
+      http = PersistentHttpClient.get(@uri, { read_timeout: read_timeout }, @api_key)
       request = Net::HTTP::Post.new(@uri, headers)
       request.body = user_context.to_json
       if request.body.length > 8000


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Experiment Ruby Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-ruby-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> no
