### PR TITLE
fix: Variant result parsing for local evaluation

### DIFF
--- a/lib/experiment/local/client.rb
+++ b/lib/experiment/local/client.rb
@@ -64,7 +64,7 @@ module AmplitudeExperiment
     def parse_results(result, flag_keys)
       variants = {}
       result.each do |key, value|
-        next if value['isDefaultVariant'] || (flag_keys.empty? && flag_keys.include?(key))
+        next if value['isDefaultVariant'] || (!flag_keys.empty? && !flag_keys.include?(key))
 
         variant_key = value['variant']['key']
         variant_payload = value['variant']['payload']

--- a/spec/experiment/local/client_spec.rb
+++ b/spec/experiment/local/client_spec.rb
@@ -83,7 +83,7 @@ module AmplitudeExperiment
         local_evaluation_client = LocalEvaluationClient.new(SERVER_API_KEY)
         local_evaluation_client.start
         result = local_evaluation_client.evaluate(TEST_USER_2, ['does-not-exist'])
-        expect(result['sdk-ci-local-dependencies-test']).to eq(Variant.new('control', nil))
+        expect(result['sdk-ci-local-dependencies-test']).to eq(nil)
       end
 
       it 'evaluation with dependencies holdout excludes variant from expeirment' do

--- a/spec/experiment/local/client_spec.rb
+++ b/spec/experiment/local/client_spec.rb
@@ -86,7 +86,7 @@ module AmplitudeExperiment
         expect(result['sdk-ci-local-dependencies-test']).to eq(nil)
       end
 
-      it 'evaluation with dependencies holdout excludes variant from expeirment' do
+      it 'evaluation with dependencies holdout excludes variant from experiment' do
         setup_stub
 
         local_evaluation_client = LocalEvaluationClient.new(SERVER_API_KEY)


### PR DESCRIPTION
### Summary

Fix variant result parsing logic for local evaluation client

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-ruby-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
