### PR TITLE
fix: Do not track empty assignment events

### DIFF
--- a/lib/experiment/local/assignment/assignment_filter.rb
+++ b/lib/experiment/local/assignment/assignment_filter.rb
@@ -6,6 +6,8 @@ module AmplitudeExperiment
     end
 
     def should_track(assignment)
+      return false if assignment.results.empty?
+
       canonical_assignment = assignment.canonicalize
       track = @cache.get(canonical_assignment).nil?
       @cache.put(canonical_assignment, 0) if track

--- a/spec/experiment/local/assignment_spec.rb
+++ b/spec/experiment/local/assignment_spec.rb
@@ -149,9 +149,9 @@ module AmplitudeExperiment
         assignment2 = Assignment.new(user1, {})
         assignment3 = Assignment.new(user2, {})
 
-        expect(filter.should_track(assignment1)).to eq(true)
+        expect(filter.should_track(assignment1)).to eq(false)
         expect(filter.should_track(assignment2)).to eq(false)
-        expect(filter.should_track(assignment3)).to eq(true)
+        expect(filter.should_track(assignment3)).to eq(false)
       end
 
       it 'filter - duplicate assignments with different result ordering' do


### PR DESCRIPTION
### Summary

Employ fix: empty assignment events are not tracked

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-ruby-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
