### PR TITLE
fix: Update AmplitudeCookies util to support new cookie format

### DIFF
--- a/lib/experiment/cookie.rb
+++ b/lib/experiment/cookie.rb
@@ -35,7 +35,7 @@ module AmplitudeExperiment
           user_session_hash = JSON.parse(json_data)
           return User.new(user_id: user_session_hash['userId'], device_id: user_session_hash['deviceId'])
         rescue StandardError
-          return User.new()
+          return nil
         end
       end
       values = amplitude_cookie.split('.', -1)

--- a/lib/experiment/cookie.rb
+++ b/lib/experiment/cookie.rb
@@ -7,11 +7,12 @@ module AmplitudeExperiment
     # Get the cookie name that Amplitude sets for the provided
     #
     # @param [String] api_key The Amplitude API Key
+    # @param [Boolean] new_format True if the cookie is in the Browser SDK 2.0 format
     # @return [String] The cookie name that Amplitude sets for the provided
-    def self.cookie_name(api_key, new: false)
+    def self.cookie_name(api_key, new_format: false)
       raise ArgumentError, 'Invalid Amplitude API Key' if api_key.nil?
 
-      if new
+      if new_format
         raise ArgumentError, 'Invalid Amplitude API Key' if api_key.length < 10
 
         return "AMP_#{api_key[0..9]}"
@@ -24,9 +25,10 @@ module AmplitudeExperiment
     # Parse a cookie string and returns user
     #
     # @param [String] amplitude_cookie A string from the amplitude cookie
+    # @param [Boolean] new_format True if the cookie is in the Browser SDK 2.0 format
     # @return [User] a Experiment User context containing a device_id and user_id
-    def self.parse(amplitude_cookie, new: false)
-      if new
+    def self.parse(amplitude_cookie, new_format: false)
+      if new_format
         begin
           decoding = Base64.decode64(amplitude_cookie).force_encoding('UTF-8')
           json_data = URI.decode_www_form_component(decoding)
@@ -51,9 +53,10 @@ module AmplitudeExperiment
     # Generates a cookie string to set for the Amplitude Javascript SDK
     #
     # @param [String] device_id A device id to set
+    # @param [Boolean] new_format True if the cookie is in the Browser SDK 2.0 format
     # @return [String] A cookie string to set for the Amplitude Javascript SDK to read
-    def self.generate(device_id, new: false)
-      return "#{device_id}.........." unless new
+    def self.generate(device_id, new_format: false)
+      return "#{device_id}.........." unless new_format
 
       user_session_hash = {
         'deviceId' => device_id

--- a/lib/experiment/cookie.rb
+++ b/lib/experiment/cookie.rb
@@ -35,7 +35,8 @@ module AmplitudeExperiment
           user_session_hash = JSON.parse(json_data)
           return User.new(user_id: user_session_hash['userId'], device_id: user_session_hash['deviceId'])
         rescue StandardError => e
-          raise ArgumentError, "Error parsing the Amplitude cookie: #{e.message}"
+          puts "Error parsing the Amplitude cookie: #{e.message}"
+          return nil
         end
       end
       values = amplitude_cookie.split('.', -1)

--- a/lib/experiment/cookie.rb
+++ b/lib/experiment/cookie.rb
@@ -34,8 +34,8 @@ module AmplitudeExperiment
           json_data = URI.decode_www_form_component(decoding)
           user_session_hash = JSON.parse(json_data)
           return User.new(user_id: user_session_hash['userId'], device_id: user_session_hash['deviceId'])
-        rescue StandardError
-          return nil
+        rescue StandardError => e
+          raise ArgumentError, "Error parsing the Amplitude cookie: #{e.message}"
         end
       end
       values = amplitude_cookie.split('.', -1)

--- a/lib/experiment/cookie.rb
+++ b/lib/experiment/cookie.rb
@@ -1,4 +1,5 @@
 require 'base64'
+require 'json'
 
 module AmplitudeExperiment
   # This class provides utility functions for parsing and handling identity from Amplitude cookies.
@@ -7,8 +8,15 @@ module AmplitudeExperiment
     #
     # @param [String] api_key The Amplitude API Key
     # @return [String] The cookie name that Amplitude sets for the provided
-    def self.cookie_name(api_key)
-      raise ArgumentError, 'Invalid Amplitude API Key' if api_key.nil? || api_key.length < 6
+    def self.cookie_name(api_key, new: false)
+      raise ArgumentError, 'Invalid Amplitude API Key' if api_key.nil?
+
+      if new
+        raise ArgumentError, 'Invalid Amplitude API Key' if api_key.length < 10
+
+        return "AMP_#{api_key[0..9]}"
+      end
+      raise ArgumentError, 'Invalid Amplitude API Key' if api_key.length < 6
 
       "amp_#{api_key[0..5]}"
     end
@@ -17,7 +25,17 @@ module AmplitudeExperiment
     #
     # @param [String] amplitude_cookie A string from the amplitude cookie
     # @return [User] a Experiment User context containing a device_id and user_id
-    def self.parse(amplitude_cookie)
+    def self.parse(amplitude_cookie, new: false)
+      if new
+        begin
+          decoding = Base64.decode64(amplitude_cookie).force_encoding('UTF-8')
+          json_data = URI.decode_www_form_component(decoding)
+          user_session_hash = JSON.parse(json_data)
+          return User.new(user_id: user_session_hash['userId'], device_id: user_session_hash['deviceId'])
+        rescue StandardError
+          return User.new()
+        end
+      end
       values = amplitude_cookie.split('.', -1)
       user_id = nil
       unless values[1].nil? || values[1].empty?
@@ -34,8 +52,15 @@ module AmplitudeExperiment
     #
     # @param [String] device_id A device id to set
     # @return [String] A cookie string to set for the Amplitude Javascript SDK to read
-    def self.generate(device_id)
-      "#{device_id}.........."
+    def self.generate(device_id, new: false)
+      return "#{device_id}.........." unless new
+
+      user_session_hash = {
+        'deviceId' => device_id
+      }
+      json_data = JSON.generate(user_session_hash)
+      encoded_json = URI.encode_www_form_component(json_data)
+      Base64.strict_encode64(encoded_json)
     end
   end
 end

--- a/spec/experiment/remote/cookie_spec.rb
+++ b/spec/experiment/remote/cookie_spec.rb
@@ -2,6 +2,11 @@ require 'spec_helper'
 
 module AmplitudeExperiment
   describe AmplitudeCookie do
+    before(:each) do
+      @user_and_device_new_cookie = 'JTdCJTIydXNlcklkJTIyJTNBJTIydGVzdCU0MGFtcGxpdHVkZS5jb20lMjIlMkMlMjJkZXZpY2VJZCUyMiUzQSUyMmRldmljZUlkJTIyJTdE'
+      @device_new_cookie = 'JTdCJTIyZGV2aWNlSWQlMjIlM0ElMjJkZXZpY2VJZCUyMiU3RA=='
+    end
+
     describe '#cookie_name' do
       it 'test invalid api key throw error' do
         expect { AmplitudeCookie.cookie_name('') }.to raise_error(ArgumentError)
@@ -9,6 +14,7 @@ module AmplitudeExperiment
 
       it 'test valid api key return cookie name' do
         expect(AmplitudeCookie.cookie_name('1234567')).to eq('amp_123456')
+        expect(AmplitudeCookie.cookie_name('1234567890', new: true)).to eq('AMP_1234567890')
       end
     end
 
@@ -17,10 +23,16 @@ module AmplitudeExperiment
         user = AmplitudeCookie.parse('deviceId...1f1gkeib1.1f1gkeib1.dv.1ir.20q')
         expect(user.device_id).to eq('deviceId')
         expect(user.user_id).to be_nil
+        user = AmplitudeCookie.parse(@device_new_cookie, new: true)
+        expect(user.device_id).to eq('deviceId')
+        expect(user.user_id).to be_nil
       end
 
       it 'test parse cookie with device id and user id' do
         user = AmplitudeCookie.parse('deviceId.dGVzdEBhbXBsaXR1ZGUuY29t..1f1gkeib1.1f1gkeib1.dv.1ir.20q')
+        expect(user.device_id).to eq('deviceId')
+        expect(user.user_id).to eq('test@amplitude.com')
+        user = AmplitudeCookie.parse(@user_and_device_new_cookie, new: true)
         expect(user.device_id).to eq('deviceId')
         expect(user.user_id).to eq('test@amplitude.com')
       end
@@ -36,13 +48,18 @@ module AmplitudeExperiment
         user = AmplitudeCookie.parse('deviceId.Y8O3Pg==..1f1gkeib1.1f1gkeib1.dv.1ir.20q')
         expect(user.device_id).to eq('deviceId')
         expect(user.user_id).to be_nil
+        user = AmplitudeCookie.parse(@user_and_device_new_cookie, new: true)
+        expect(user.device_id).to be_nil
+        expect(user.user_id).to be_nil
       end
     end
 
     describe '#generate' do
       it 'test generate' do
-        result = AmplitudeCookie.generate('deviceId')
-        expect(result).to eq('deviceId..........')
+        old = AmplitudeCookie.generate('deviceId')
+        expect(old).to eq('deviceId..........')
+        new = AmplitudeCookie.generate('deviceId', new: true)
+        expect(new).to eq(@device_new_cookie)
       end
     end
   end

--- a/spec/experiment/remote/cookie_spec.rb
+++ b/spec/experiment/remote/cookie_spec.rb
@@ -14,7 +14,7 @@ module AmplitudeExperiment
 
       it 'test valid api key return cookie name' do
         expect(AmplitudeCookie.cookie_name('1234567')).to eq('amp_123456')
-        expect(AmplitudeCookie.cookie_name('1234567890', new: true)).to eq('AMP_1234567890')
+        expect(AmplitudeCookie.cookie_name('1234567890', new_format: true)).to eq('AMP_1234567890')
       end
     end
 
@@ -23,7 +23,7 @@ module AmplitudeExperiment
         user = AmplitudeCookie.parse('deviceId...1f1gkeib1.1f1gkeib1.dv.1ir.20q')
         expect(user.device_id).to eq('deviceId')
         expect(user.user_id).to be_nil
-        user = AmplitudeCookie.parse(@device_new_cookie, new: true)
+        user = AmplitudeCookie.parse(@device_new_cookie, new_format: true)
         expect(user.device_id).to eq('deviceId')
         expect(user.user_id).to be_nil
       end
@@ -32,7 +32,7 @@ module AmplitudeExperiment
         user = AmplitudeCookie.parse('deviceId.dGVzdEBhbXBsaXR1ZGUuY29t..1f1gkeib1.1f1gkeib1.dv.1ir.20q')
         expect(user.device_id).to eq('deviceId')
         expect(user.user_id).to eq('test@amplitude.com')
-        user = AmplitudeCookie.parse(@user_and_device_new_cookie, new: true)
+        user = AmplitudeCookie.parse(@user_and_device_new_cookie, new_format: true)
         expect(user.device_id).to eq('deviceId')
         expect(user.user_id).to eq('test@amplitude.com')
       end
@@ -48,7 +48,7 @@ module AmplitudeExperiment
         user = AmplitudeCookie.parse('deviceId.Y8O3Pg==..1f1gkeib1.1f1gkeib1.dv.1ir.20q')
         expect(user.device_id).to eq('deviceId')
         expect(user.user_id).to be_nil
-        user = AmplitudeCookie.parse(@user_and_device_new_cookie, new: true)
+        user = AmplitudeCookie.parse(@user_and_device_new_cookie, new_format: true)
         expect(user.device_id).to be_nil
         expect(user.user_id).to be_nil
       end
@@ -58,7 +58,7 @@ module AmplitudeExperiment
       it 'test generate' do
         old = AmplitudeCookie.generate('deviceId')
         expect(old).to eq('deviceId..........')
-        new = AmplitudeCookie.generate('deviceId', new: true)
+        new = AmplitudeCookie.generate('deviceId', new_format: true)
         expect(new).to eq(@device_new_cookie)
       end
     end

--- a/spec/experiment/remote/cookie_spec.rb
+++ b/spec/experiment/remote/cookie_spec.rb
@@ -49,8 +49,7 @@ module AmplitudeExperiment
         expect(user.device_id).to eq('deviceId')
         expect(user.user_id).to be_nil
         user = AmplitudeCookie.parse(@user_and_device_new_cookie, new_format: true)
-        expect(user.device_id).to be_nil
-        expect(user.user_id).to be_nil
+        expect(user).to eq(nil)
       end
     end
 


### PR DESCRIPTION
### Summary

Update AmplitudeCookies util to support new cookie format

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-ruby-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
