### PR TITLE
fix: Add error handling to local evaluation flag poller

### DIFF
--- a/lib/experiment/local/client.rb
+++ b/lib/experiment/local/client.rb
@@ -88,9 +88,13 @@ module AmplitudeExperiment
 
     def run
       @is_running = true
-      flags = @fetcher.fetch_v1
-      @flags_mutex.synchronize do
-        @flags = flags
+      begin
+        flags = @fetcher.fetch_v1
+        @flags_mutex.synchronize do
+          @flags = flags
+        end
+      rescue StandardError => e
+        @logger.error("[Experiment] Flag poller - error: #{e.message}")
       end
       @poller_thread = Thread.new do
         sleep(@config.flag_config_polling_interval_millis / 1000.to_f)


### PR DESCRIPTION
### Summary

Add error handling to local evaluation flag poller. If there is an exception when polling for flag configs, the most recent flag configs are used

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-ruby-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
