### PR TITLE
fix: Add options for RemoteEvaluationClient variant fetch

### DIFF
--- a/lib/experiment/remote/client.rb
+++ b/lib/experiment/remote/client.rb
@@ -25,7 +25,7 @@ module AmplitudeExperiment
     end
 
     # Synchronously fetch user variants for the given flag keys.
-    # If flag key is not provided, all variants will be returned.
+    # If flag keys are not provided, all variants will be returned.
     #
     # This method will automatically retry if configured (default).
     # @param [User] user

--- a/lib/experiment/remote/client.rb
+++ b/lib/experiment/remote/client.rb
@@ -24,7 +24,7 @@ module AmplitudeExperiment
       raise ArgumentError, 'Experiment API key is empty' if @api_key.nil? || @api_key.empty?
     end
 
-    # Fetch variants for a user synchronously for the given flag keys.
+    # Synchronously fetch user variants for the given flag keys.
     # If flag key is not provided, all variants will be returned.
     #
     # This method will automatically retry if configured (default).
@@ -38,8 +38,8 @@ module AmplitudeExperiment
       {}
     end
 
-    # Fetch variants for a user asynchronously for the given flag keys.
-    # If flag key is not provided, all variants will be returned.
+    # Asynchronously fetch user variants for the given flag keys.
+    # If flag keys are not provided, all variants will be returned.
     #
     # This method will automatically retry if configured (default).
     # @param [User] user


### PR DESCRIPTION
### Summary

Add options for RemoteEvaluationClient variant fetch

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-ruby-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
