### PR TITLE
feat: Enable use of project API key for default deployments

### DIFF
--- a/lib/experiment/factory.rb
+++ b/lib/experiment/factory.rb
@@ -6,7 +6,8 @@ module AmplitudeExperiment
   # Initializes a singleton Client. This method returns a default singleton instance, subsequent calls to
   #  init will return the initial instance regardless of input.
   #
-  # @param [String] api_key The environment API Key. If a deployment key is provided in the config, it will be used instead.
+  # @param [String] api_key The Amplitude Project API Key used in the client. If a deployment key is provided in
+  # the config, it will be used instead.
   # @param [Config] config Optional Config.
   def self.initialize_remote(api_key, config = nil)
     used_key = config&.deployment_key.nil? ? api_key : config.deployment_key
@@ -18,7 +19,8 @@ module AmplitudeExperiment
   # user without requiring a remote call to the amplitude evaluation server. In order to best leverage local
   # evaluation, all flags, and experiments being evaluated server side should be configured as local.
   #
-  # @param [String] api_key The environment API Key. If a deployment key is provided in the config, it will be used instead.
+  # @param [String] api_key The Amplitude Project API Key used in the client. If a deployment key is provided in
+  # the config, it will be used instead.
   # @param [Config] config Optional Config.
   def self.initialize_local(api_key, config = nil)
     used_key = config&.deployment_key.nil? ? api_key : config.deployment_key

--- a/lib/experiment/factory.rb
+++ b/lib/experiment/factory.rb
@@ -6,21 +6,23 @@ module AmplitudeExperiment
   # Initializes a singleton Client. This method returns a default singleton instance, subsequent calls to
   #  init will return the initial instance regardless of input.
   #
-  # @param [String] api_key The environment API Key
+  # @param [String] api_key The environment API Key. If a deployment key is provided in the config, it will be used instead.
   # @param [Config] config Optional Config.
   def self.initialize_remote(api_key, config = nil)
-    @remote_instance.store(api_key, RemoteEvaluationClient.new(api_key, config)) unless @remote_instance.key?(api_key)
-    @remote_instance.fetch(api_key)
+    used_key = config&.deployment_key.nil? ? api_key : config.deployment_key
+    @remote_instance.store(used_key, RemoteEvaluationClient.new(used_key, config)) unless @remote_instance.key?(used_key)
+    @remote_instance.fetch(used_key)
   end
 
   # Initializes a local evaluation Client. A local evaluation client can evaluate local flags or experiments for a
   # user without requiring a remote call to the amplitude evaluation server. In order to best leverage local
   # evaluation, all flags, and experiments being evaluated server side should be configured as local.
   #
-  # @param [String] api_key The environment API Key
+  # @param [String] api_key The environment API Key. If a deployment key is provided in the config, it will be used instead.
   # @param [Config] config Optional Config.
   def self.initialize_local(api_key, config = nil)
-    @local_instance.store(api_key, LocalEvaluationClient.new(api_key, config)) unless @local_instance.key?(api_key)
-    @local_instance.fetch(api_key)
+    used_key = config&.deployment_key.nil? ? api_key : config.deployment_key
+    @local_instance.store(used_key, LocalEvaluationClient.new(used_key, config)) unless @local_instance.key?(used_key)
+    @local_instance.fetch(used_key)
   end
 end

--- a/lib/experiment/local/config.rb
+++ b/lib/experiment/local/config.rb
@@ -20,7 +20,7 @@ module AmplitudeExperiment
     # @return [AssignmentConfig] the config instance
     attr_accessor :assignment_config
 
-    # The deployment key for the experiment. If provided, it is used instead of the Project API Key.
+    # The deployment key for the experiment. If provided, it is used instead of the Amplitude Project API Key.
     # @return [String] the value of deployment_key
     attr_accessor :deployment_key
 

--- a/lib/experiment/local/config.rb
+++ b/lib/experiment/local/config.rb
@@ -20,17 +20,23 @@ module AmplitudeExperiment
     # @return [AssignmentConfig] the config instance
     attr_accessor :assignment_config
 
+    # The deployment key for the experiment. If provided, it is used instead of the Project API Key.
+    # @return [String] the value of deployment_key
+    attr_accessor :deployment_key
+
     # @param [Boolean] debug Set to true to log some extra information to the console.
     # @param [String] server_url The server endpoint from which to request variants.
     # @param [Hash] bootstrap The value of bootstrap.
     # @param [long] flag_config_polling_interval_millis The value of flag config polling interval in million seconds.
     def initialize(server_url: DEFAULT_SERVER_URL, bootstrap: {},
-                   flag_config_polling_interval_millis: 30_000, debug: false, assignment_config: nil)
+                   flag_config_polling_interval_millis: 30_000, debug: false, assignment_config: nil,
+                   deployment_key: nil)
       @debug = debug || false
       @server_url = server_url
       @bootstrap = bootstrap
       @flag_config_polling_interval_millis = flag_config_polling_interval_millis
       @assignment_config = assignment_config
+      @deployment_key = deployment_key
     end
   end
 end

--- a/lib/experiment/remote/config.rb
+++ b/lib/experiment/remote/config.rb
@@ -38,7 +38,7 @@ module AmplitudeExperiment
     # @return [Integer] the value of fetch_retry_timeout_millis
     attr_accessor :fetch_retry_timeout_millis
 
-    # The deployment key for the experiment. If provided, it is used instead of the Project API Key.
+    # The deployment key for the experiment. If provided, it is used instead of the Amplitude Project API Key.
     # @return [String] the value of deployment_key
     attr_accessor :deployment_key
 

--- a/lib/experiment/remote/config.rb
+++ b/lib/experiment/remote/config.rb
@@ -64,7 +64,7 @@ module AmplitudeExperiment
       @fetch_retry_backoff_max_millis = fetch_retry_backoff_max_millis
       @fetch_retry_backoff_scalar = fetch_retry_backoff_scalar
       @fetch_retry_timeout_millis = fetch_retry_timeout_millis
-      @deployment_key = @deployment_key
+      @deployment_key = deployment_key
     end
   end
 end

--- a/lib/experiment/remote/config.rb
+++ b/lib/experiment/remote/config.rb
@@ -38,6 +38,10 @@ module AmplitudeExperiment
     # @return [Integer] the value of fetch_retry_timeout_millis
     attr_accessor :fetch_retry_timeout_millis
 
+    # The deployment key for the experiment. If provided, it is used instead of the Project API Key.
+    # @return [String] the value of deployment_key
+    attr_accessor :deployment_key
+
     # @param [Boolean] debug Set to true to log some extra information to the console.
     # @param [String] server_url The server endpoint from which to request variants.
     # @param [Integer] fetch_timeout_millis The request timeout, in milliseconds, used when fetching variants
@@ -51,7 +55,7 @@ module AmplitudeExperiment
     # @param [Integer] fetch_retry_timeout_millis The request timeout for retrying fetch requests.
     def initialize(debug: false, server_url: DEFAULT_SERVER_URL, fetch_timeout_millis: 10_000, fetch_retries: 0,
                    fetch_retry_backoff_min_millis: 500, fetch_retry_backoff_max_millis: 10_000,
-                   fetch_retry_backoff_scalar: 1.5, fetch_retry_timeout_millis: 10_000)
+                   fetch_retry_backoff_scalar: 1.5, fetch_retry_timeout_millis: 10_000, deployment_key: nil)
       @debug = debug
       @server_url = server_url
       @fetch_timeout_millis = fetch_timeout_millis
@@ -60,6 +64,7 @@ module AmplitudeExperiment
       @fetch_retry_backoff_max_millis = fetch_retry_backoff_max_millis
       @fetch_retry_backoff_scalar = fetch_retry_backoff_scalar
       @fetch_retry_timeout_millis = fetch_retry_timeout_millis
+      @deployment_key = @deployment_key
     end
   end
 end


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Experiment Ruby Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Enable use of project API key for default deployments

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-ruby-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  No
