### PR TITLE
feat: added open timeout

### DIFF
--- a/lib/experiment/persistent_http_client.rb
+++ b/lib/experiment/persistent_http_client.rb
@@ -5,7 +5,7 @@ module AmplitudeExperiment
   # WARNING: these connections are not safe for concurrent requests. Callers
   # must synchronize requests per connection.
   class PersistentHttpClient
-    DEFAULT_OPTIONS = { read_timeout: 80 }.freeze
+    DEFAULT_OPTIONS = { open_timeout: 60, read_timeout: 80 }.freeze
 
     class << self
       # url: URI / String

--- a/lib/experiment/remote/client.rb
+++ b/lib/experiment/remote/client.rb
@@ -123,7 +123,8 @@ module AmplitudeExperiment
     end
 
     # @param [User] user
-    # @param [Integer] timeout_millis
+    # @param [Integer] connect_timeout_millis
+    # @param [Integer] fetch_timeout_millis
     def do_fetch(user, connect_timeout_millis, fetch_timeout_millis)
       start_time = Time.now
       user_context = add_context(user)

--- a/lib/experiment/remote/client.rb
+++ b/lib/experiment/remote/client.rb
@@ -89,7 +89,7 @@ module AmplitudeExperiment
     # @param [User] user
     def fetch_internal(user)
       @logger.debug("[Experiment] Fetching variants for user: #{user.as_json}")
-      do_fetch(user, @config.fetch_timeout_millis)
+      do_fetch(user, @config.open_timeout_millis, @config.fetch_timeout_millis)
     rescue StandardError => e
       @logger.error("[Experiment] Fetch failed: #{e.message}")
       if should_retry_fetch?(e)
@@ -112,7 +112,7 @@ module AmplitudeExperiment
       @config.fetch_retries.times do
         sleep(delay_millis.to_f / 1000.0)
         begin
-          return do_fetch(user, @config.fetch_retry_timeout_millis)
+          return do_fetch(user, @config.open_timeout_millis, @config.fetch_retry_timeout_millis)
         rescue StandardError => e
           @logger.error("[Experiment] Retry failed: #{e.message}")
           err = e
@@ -124,15 +124,16 @@ module AmplitudeExperiment
 
     # @param [User] user
     # @param [Integer] timeout_millis
-    def do_fetch(user, timeout_millis)
+    def do_fetch(user, open_timeout_millis, fetch_timeout_millis)
       start_time = Time.now
       user_context = add_context(user)
       headers = {
         'Authorization' => "Api-Key #{@api_key}",
         'Content-Type' => 'application/json;charset=utf-8'
       }
-      read_timeout = timeout_millis.to_f / 1000 if (timeout_millis.to_f / 1000) > 0
-      http = PersistentHttpClient.get(@uri, { read_timeout: read_timeout }, @api_key)
+      open_timeout = open_timeout_millis.to_f / 1000 if (open_timeout_millis.to_f / 1000) > 0
+      read_timeout = fetch_timeout_millis.to_f / 1000 if (fetch_timeout_millis.to_f / 1000) > 0
+      http = PersistentHttpClient.get(@uri, { open_timeout: open_timeout, read_timeout: read_timeout }, @api_key)
       request = Net::HTTP::Post.new(@uri, headers)
       request.body = user_context.to_json
       @logger.warn("[Experiment] encoded user object length #{request.body.length} cannot be cached by CDN; must be < 8KB") if request.body.length > 8000

--- a/lib/experiment/remote/config.rb
+++ b/lib/experiment/remote/config.rb
@@ -13,8 +13,8 @@ module AmplitudeExperiment
     attr_accessor :server_url
 
     # The request connection open timeout, in milliseconds, used when fetching variants triggered by calling start() or setUser().
-    # @return [Integer] the value of open_timeout_millis
-    attr_accessor :open_timeout_millis
+    # @return [Integer] the value of connect_timeout_millis
+    attr_accessor :connect_timeout_millis
 
     # The request timeout, in milliseconds, used when fetching variants triggered by calling start() or setUser().
     # @return [Integer] the value of fetch_timeout_millis
@@ -44,7 +44,7 @@ module AmplitudeExperiment
 
     # @param [Boolean] debug Set to true to log some extra information to the console.
     # @param [String] server_url The server endpoint from which to request variants.
-    # @param [Integer] open_timeout_millis The request connection open timeout, in milliseconds, used when
+    # @param [Integer] connect_timeout_millis The request connection open timeout, in milliseconds, used when
     #  fetching variants triggered by calling start() or setUser().
     # @param [Integer] fetch_timeout_millis The request timeout, in milliseconds, used when fetching variants
     #  triggered by calling start() or setUser().
@@ -55,12 +55,12 @@ module AmplitudeExperiment
     #  greater than the max, the max is used for all subsequent retries.
     # @param [Float] fetch_retry_backoff_scalar Scales the minimum backoff exponentially.
     # @param [Integer] fetch_retry_timeout_millis The request timeout for retrying fetch requests.
-    def initialize(debug: false, server_url: DEFAULT_SERVER_URL, open_timeout_millis: 60_000, fetch_timeout_millis: 10_000, fetch_retries: 0,
+    def initialize(debug: false, server_url: DEFAULT_SERVER_URL, connect_timeout_millis: 60_000, fetch_timeout_millis: 10_000, fetch_retries: 0,
                    fetch_retry_backoff_min_millis: 500, fetch_retry_backoff_max_millis: 10_000,
                    fetch_retry_backoff_scalar: 1.5, fetch_retry_timeout_millis: 10_000)
       @debug = debug
       @server_url = server_url
-      @open_timeout_millis = open_timeout_millis
+      @connect_timeout_millis = connect_timeout_millis
       @fetch_timeout_millis = fetch_timeout_millis
       @fetch_retries = fetch_retries
       @fetch_retry_backoff_min_millis = fetch_retry_backoff_min_millis

--- a/lib/experiment/remote/config.rb
+++ b/lib/experiment/remote/config.rb
@@ -12,6 +12,10 @@ module AmplitudeExperiment
     # @return [Boolean] the value of server url
     attr_accessor :server_url
 
+    # The request connection open timeout, in milliseconds, used when fetching variants triggered by calling start() or setUser().
+    # @return [Integer] the value of open_timeout_millis
+    attr_accessor :open_timeout_millis
+
     # The request timeout, in milliseconds, used when fetching variants triggered by calling start() or setUser().
     # @return [Integer] the value of fetch_timeout_millis
     attr_accessor :fetch_timeout_millis
@@ -40,6 +44,8 @@ module AmplitudeExperiment
 
     # @param [Boolean] debug Set to true to log some extra information to the console.
     # @param [String] server_url The server endpoint from which to request variants.
+    # @param [Integer] open_timeout_millis The request connection open timeout, in milliseconds, used when
+    #  fetching variants triggered by calling start() or setUser().
     # @param [Integer] fetch_timeout_millis The request timeout, in milliseconds, used when fetching variants
     #  triggered by calling start() or setUser().
     # @param [Integer] fetch_retries The number of retries to attempt before failing.
@@ -49,11 +55,12 @@ module AmplitudeExperiment
     #  greater than the max, the max is used for all subsequent retries.
     # @param [Float] fetch_retry_backoff_scalar Scales the minimum backoff exponentially.
     # @param [Integer] fetch_retry_timeout_millis The request timeout for retrying fetch requests.
-    def initialize(debug: false, server_url: DEFAULT_SERVER_URL, fetch_timeout_millis: 10_000, fetch_retries: 0,
+    def initialize(debug: false, server_url: DEFAULT_SERVER_URL, open_timeout_millis: 60_000, fetch_timeout_millis: 10_000, fetch_retries: 0,
                    fetch_retry_backoff_min_millis: 500, fetch_retry_backoff_max_millis: 10_000,
                    fetch_retry_backoff_scalar: 1.5, fetch_retry_timeout_millis: 10_000)
       @debug = debug
       @server_url = server_url
+      @open_timeout_millis = open_timeout_millis
       @fetch_timeout_millis = fetch_timeout_millis
       @fetch_retries = fetch_retries
       @fetch_retry_backoff_min_millis = fetch_retry_backoff_min_millis

--- a/spec/experiment/remote/client_spec.rb
+++ b/spec/experiment/remote/client_spec.rb
@@ -62,6 +62,16 @@ module AmplitudeExperiment
       test_fetch_shared response_without_payload, test_user, variant_name, false, Variant.new(key: 'on')
       test_fetch_shared response_with_value_without_payload, test_user, variant_name, false, Variant.new(value: 'on')
 
+      it 'open timeout failure' do
+        stub_request(:post, server_url)
+          .to_timeout
+        test_user = User.new(user_id: 'test_user')
+        client = RemoteEvaluationClient.new(api_key, RemoteEvaluationConfig.new(open_timeout_millis: 1, fetch_retries: 1, debug: true))
+        variants = nil
+        expect { variants = client.fetch(test_user) }.to output(/Retrying fetch/).to_stdout_from_any_process
+        expect(variants).to eq({})
+      end
+
       it 'fetch timeout failure' do
         stub_request(:post, server_url)
           .to_timeout
@@ -145,6 +155,16 @@ module AmplitudeExperiment
       test_fetch_v2_shared response_with_hash_payload, test_user_with_properties, variant_name, false, Variant.new(key: 'off', payload: { 'nested' => 'nested payload' })
       test_fetch_v2_shared response_without_payload, test_user, variant_name, false, Variant.new(key: 'on')
       test_fetch_v2_shared response_with_value_without_payload, test_user, variant_name, false, Variant.new(value: 'on')
+
+      it 'fetch v2 open timeout failure' do
+        stub_request(:post, server_url)
+          .to_timeout
+        test_user = User.new(user_id: 'test_user')
+        client = RemoteEvaluationClient.new(api_key, RemoteEvaluationConfig.new(open_timeout_millis: 1, fetch_retries: 1, debug: true))
+        variants = nil
+        expect { variants = client.fetch_v2(test_user) }.to output(/Retrying fetch/).to_stdout_from_any_process
+        expect(variants).to eq({})
+      end
 
       it 'fetch v2 timeout failure' do
         stub_request(:post, server_url)

--- a/spec/experiment/remote/client_spec.rb
+++ b/spec/experiment/remote/client_spec.rb
@@ -66,7 +66,7 @@ module AmplitudeExperiment
         stub_request(:post, server_url)
           .to_timeout
         test_user = User.new(user_id: 'test_user')
-        client = RemoteEvaluationClient.new(api_key, RemoteEvaluationConfig.new(open_timeout_millis: 1, fetch_retries: 1, debug: true))
+        client = RemoteEvaluationClient.new(api_key, RemoteEvaluationConfig.new(connect_timeout_millis: 1, fetch_retries: 1, debug: true))
         variants = nil
         expect { variants = client.fetch(test_user) }.to output(/Retrying fetch/).to_stdout_from_any_process
         expect(variants).to eq({})
@@ -160,7 +160,7 @@ module AmplitudeExperiment
         stub_request(:post, server_url)
           .to_timeout
         test_user = User.new(user_id: 'test_user')
-        client = RemoteEvaluationClient.new(api_key, RemoteEvaluationConfig.new(open_timeout_millis: 1, fetch_retries: 1, debug: true))
+        client = RemoteEvaluationClient.new(api_key, RemoteEvaluationConfig.new(connect_timeout_millis: 1, fetch_retries: 1, debug: true))
         variants = nil
         expect { variants = client.fetch_v2(test_user) }.to output(/Retrying fetch/).to_stdout_from_any_process
         expect(variants).to eq({})


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude Experiment Ruby Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Adding open timeout. 

```
module AmplitudeExperiment
  client = RemoteEvaluationClient.new("client-v0KqDA8KnJE4JHS3ZDaQTiwgjZENDMiR", RemoteEvaluationConfig.new(open_timeout_millis: 1, fetch_retries: 1, debug: true))
  client.fetch(User.new(user_id: "test_user", device_id: "test_device"))
end
```

Now causes: 
```
D, [2025-04-06T23:23:10.319547 #3019] DEBUG -- : [Experiment] Fetching variants for user: {"device_id"=>"test_device", "user_id"=>"test_user"}
E, [2025-04-06T23:23:10.349484 #3019] ERROR -- : [Experiment] Fetch failed: execution expired
D, [2025-04-06T23:23:10.349530 #3019] DEBUG -- : [Experiment] Retrying fetch
E, [2025-04-06T23:23:10.854912 #3019] ERROR -- : [Experiment] Retry failed: execution expired
E, [2025-04-06T23:23:10.855015 #3019] ERROR -- : [Experiment] Retry Fetch failed: uncaught throw #<Net::OpenTimeout: execution expired>
E, [2025-04-06T23:23:10.855033 #3019] ERROR -- : [Experiment] Failed to fetch variants: execution expired
```

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiments-ruby-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
