### PR TITLE
feat: match array properties element-wise for non-set operators

### DIFF
--- a/lib/experiment/evaluation/evaluation.rb
+++ b/lib/experiment/evaluation/evaluation.rb
@@ -66,22 +66,23 @@ module AmplitudeExperiment
 
       def match_condition(target, condition)
         prop_value = Evaluation.select(target, condition.selector)
-        # Special matching for null properties and set type prop values and operators
-        if !prop_value
-          match_null(condition.op, condition.values)
-        elsif set_operator?(condition.op)
-          prop_value_string_list = coerce_string_array(prop_value)
+        return match_null(condition.op, condition.values) unless prop_value
+
+        prop_value_string_list = coerce_string_array(prop_value)
+        if set_operator?(condition.op)
           return false unless prop_value_string_list
 
           match_set(prop_value_string_list, condition.op, condition.values)
+        elsif prop_value_string_list
+          match_strings_non_set(prop_value_string_list, condition.op, condition.values)
         else
           prop_value_string = coerce_string(prop_value)
-          if prop_value_string
-            match_string(prop_value_string, condition.op, condition.values)
-          else
-            false
-          end
+          prop_value_string ? match_string(prop_value_string, condition.op, condition.values) : false
         end
+      end
+
+      def match_strings_non_set(prop_values, op, filter_values)
+        prop_values.any? { |v| match_string(v, op, filter_values) }
       end
 
       def get_hash(key)
@@ -263,23 +264,19 @@ module AmplitudeExperiment
       end
 
       def coerce_string_array(value)
-        if value.is_a?(Array)
-          value.map { |e| coerce_string(e) }.compact
-        else
-          string_value = value.to_s
-          begin
-            parsed_value = JSON.parse(string_value)
-            if parsed_value.is_a?(Array)
-              parsed_value.map { |e| coerce_string(e) }.compact
-            else
-              s = coerce_string(string_value)
-              s ? [s] : nil
-            end
-          rescue JSON::ParserError
-            s = coerce_string(string_value)
-            s ? [s] : nil
-          end
+        return value.map { |e| coerce_string(e) }.compact if value.is_a?(Array)
+
+        string_value = value.to_s
+        return nil unless string_value.start_with?('[')
+
+        begin
+          parsed_value = JSON.parse(string_value)
+        rescue JSON::ParserError
+          return nil
         end
+        return nil unless parsed_value.is_a?(Array)
+
+        parsed_value.map { |e| coerce_string(e) }.compact
       end
 
       def set_operator?(op)

--- a/spec/experiment/evaluation/evaluation_intgration_spec.rb
+++ b/spec/experiment/evaluation/evaluation_intgration_spec.rb
@@ -4,6 +4,10 @@ require 'net/http'
 require 'json'
 
 module AmplitudeExperiment
+  # Cached once to work around a JRuby 10.x issue where repeated URI() parsing
+  # under sustained string allocation spuriously raises "URI must be ascii only".
+  FLAGS_URI = URI('https://api.lab.amplitude.com/sdk/v2/flags?eval_mode=remote').freeze
+
   describe Evaluation::Engine do
     let(:deployment_key) { 'server-VVhLULXCxxY0xqmszXouXxiEzoeJWmSh' }
     let(:engine) { Evaluation::Engine.new }
@@ -521,13 +525,10 @@ module AmplitudeExperiment
     end
 
     def get_flags(deployment_key)
-      server_url = 'https://api.lab.amplitude.com'
-      uri = URI("#{server_url}/sdk/v2/flags?eval_mode=remote")
-
-      request = Net::HTTP::Get.new(uri)
+      request = Net::HTTP::Get.new(FLAGS_URI)
       request['Authorization'] = "Api-Key #{deployment_key}"
 
-      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+      response = Net::HTTP.start(FLAGS_URI.hostname, FLAGS_URI.port, use_ssl: true) do |http|
         http.request(request)
       end
 

--- a/spec/experiment/evaluation/evaluation_intgration_spec.rb
+++ b/spec/experiment/evaluation/evaluation_intgration_spec.rb
@@ -5,7 +5,7 @@ require 'json'
 
 module AmplitudeExperiment
   describe Evaluation::Engine do
-    let(:deployment_key) { 'server-NgJxxvg8OGwwBsWVXqyxQbdiflbhvugy' }
+    let(:deployment_key) { 'server-VVhLULXCxxY0xqmszXouXxiEzoeJWmSh' }
     let(:engine) { Evaluation::Engine.new }
     let(:flags) { get_flags(deployment_key) }
 
@@ -418,6 +418,48 @@ module AmplitudeExperiment
       it 'tests glob does not match' do
         user = user_context(nil, nil, nil, { 'key' => '/path/1/2/3' })
         result = engine.evaluate(user, flags)['test-glob-does-not-match']
+        expect(result.key).to eq('on')
+      end
+
+      it 'tests set is with json array string' do
+        user = user_context(nil, nil, nil, { 'key' => '["1", "2", "3"]' })
+        result = engine.evaluate(user, flags)['test-set-is']
+        expect(result.key).to eq('on')
+      end
+
+      it 'tests is with array' do
+        user = user_context(nil, nil, nil, { 'key' => %w[value1 value2] })
+        result = engine.evaluate(user, flags)['test-is-array']
+        expect(result.key).to eq('on')
+      end
+
+      it 'tests is with json array string' do
+        user = user_context(nil, nil, nil, { 'key' => '["value1", "value2"]' })
+        result = engine.evaluate(user, flags)['test-is-array']
+        expect(result.key).to eq('on')
+      end
+
+      it 'tests is not with array' do
+        user = user_context(nil, nil, nil, { 'key' => %w[value3 value4] })
+        result = engine.evaluate(user, flags)['test-is-not-array']
+        expect(result.key).to eq('on')
+      end
+
+      it 'tests contains with array' do
+        user = user_context(nil, nil, nil, { 'key' => %w[has-target-value has value] })
+        result = engine.evaluate(user, flags)['test-contains-array']
+        expect(result.key).to eq('on')
+      end
+
+      it 'tests does not contain with array' do
+        user = user_context(nil, nil, nil, { 'key' => %w[has-value has value] })
+        result = engine.evaluate(user, flags)['test-does-not-contain-array']
+        expect(result.key).to eq('on')
+      end
+
+      it 'tests does not contain with json array string' do
+        user = user_context(nil, nil, nil, { 'key' => '["has-value", "has", "value"]' })
+        result = engine.evaluate(user, flags)['test-does-not-contain-array']
         expect(result.key).to eq('on')
       end
 

--- a/spec/experiment/evaluation/evaluation_spec.rb
+++ b/spec/experiment/evaluation/evaluation_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module AmplitudeExperiment
+  describe Evaluation::Engine do
+    let(:engine) { Evaluation::Engine.new }
+
+    def flag_with_condition(op, values)
+      Evaluation::Flag.from_hash(
+        'key' => 'test-flag',
+        'variants' => {
+          'on' => { 'key' => 'on', 'value' => 'on' }
+        },
+        'segments' => [
+          {
+            'conditions' => [[
+              {
+                'selector' => %w[context user user_properties test_prop],
+                'op' => op,
+                'values' => values
+              }
+            ]],
+            'variant' => 'on'
+          }
+        ]
+      )
+    end
+
+    def context_with_prop(value)
+      {
+        'user' => {
+          'user_properties' => { 'test_prop' => value }
+        }
+      }
+    end
+
+    def evaluate(prop_value, op, values)
+      flag = flag_with_condition(op, values)
+      context = context_with_prop(prop_value)
+      engine.evaluate(context, [flag])['test-flag']
+    end
+
+    def assert_match(prop_value, op, values)
+      result = evaluate(prop_value, op, values)
+      expect(result).not_to be_nil
+      expect(result.key).to eq('on')
+    end
+
+    def assert_no_match(prop_value, op, values)
+      result = evaluate(prop_value, op, values)
+      expect(result).to be_nil
+    end
+
+    describe 'non-set operator array matching' do
+      it 'matches scalar string IS' do
+        assert_match('hello', Evaluation::Operator::IS, ['hello'])
+      end
+
+      it 'matches scalar string CONTAINS' do
+        assert_match('hello', Evaluation::Operator::CONTAINS, ['ell'])
+      end
+
+      it 'matches scalar string GREATER_THAN' do
+        assert_match('2', Evaluation::Operator::GREATER_THAN, ['1'])
+      end
+
+      it 'does not match scalar string IS when value differs' do
+        assert_no_match('world', Evaluation::Operator::IS, ['hello'])
+      end
+
+      it 'matches non-string scalar GREATER_THAN' do
+        assert_match(42, Evaluation::Operator::GREATER_THAN, ['1'])
+      end
+
+      it 'matches non-string scalar IS (boolean)' do
+        assert_match(true, Evaluation::Operator::IS, ['true'])
+      end
+
+      it 'matches JSON array string with set operator' do
+        assert_match('["a","b"]', Evaluation::Operator::SET_CONTAINS, ['a'])
+      end
+
+      it 'matches JSON array string with non-set operator' do
+        assert_match('["a","b"]', Evaluation::Operator::IS, ['a'])
+      end
+
+      it 'matches collection with set operator' do
+        assert_match(%w[a b], Evaluation::Operator::SET_CONTAINS, ['a'])
+      end
+
+      it 'matches collection with non-set operator' do
+        assert_match(%w[a b], Evaluation::Operator::IS, ['a'])
+      end
+
+      it 'falls through for malformed JSON array and matches as scalar' do
+        assert_match('[broken', Evaluation::Operator::IS, ['[broken'])
+      end
+
+      it 'does not match empty JSON array for set operator' do
+        assert_no_match('[]', Evaluation::Operator::SET_CONTAINS, ['a'])
+      end
+
+      it 'treats leading-whitespace string as scalar for non-set operator' do
+        assert_match(' ["a"]', Evaluation::Operator::IS, [' ["a"]'])
+      end
+
+      it 'treats leading-whitespace string as scalar for set operator (no match)' do
+        assert_no_match(' ["a"]', Evaluation::Operator::SET_CONTAINS, ['a'])
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Adds element-wise (any-match) evaluation for multi-valued user properties when paired with non-set operators (`is`, `contains`, `greater`, etc.), aligning the local evaluation engine with Amplitude analytics/charts behavior.

Previously, non-set operators always stringified the whole property value via `coerce_string` — so an array property like `["a","b"]` would never satisfy `is "a"`. Now:

- `match_condition` calls `coerce_string_array` for every non-null value. If the value is multi-valued (native array or JSON array string) and the operator is non-set, it delegates to a new `match_strings_non_set` helper that returns true if **any** element satisfies the operator.
- Negation operators (`is not`, `does not contain`) also use any-match semantics — `is not "A"` on `["A","B"]` is `true` because `"B"` is not `"A"`.
- Scalars still fall through to the existing `coerce_string` → `match_string` path unchanged.

Also fixes two issues in `coerce_string_array`:

- Added a `start_with?('[')` pre-check so scalar strings skip `JSON.parse` and avoid exception-driven control flow on every evaluation.
- Corrected a pre-existing bug where scalars (non-array JSON or malformed JSON) were returned as `[value]` instead of `nil`, which caused set operators to spuriously match single-string properties.

### Tests

- New `spec/experiment/evaluation/evaluation_spec.rb` with an inline test harness (`flag_with_condition`, `context_with_prop`, `evaluate`, `assert_match`, `assert_no_match`) and 14 unit cases covering scalars, native arrays, JSON array strings, malformed JSON, and leading-whitespace edge cases.
- 7 new integration cases added inline in the existing `operator tests` block; the deployment key is consolidated to `server-VVhLULXCxxY0xqmszXouXxiEzoeJWmSh` (a superset of the prior key, containing all existing flags plus the new multi-value flags).

Full suite: 271 examples, 0 failures. Rubocop: clean.

### Checklist

- [x] Does your PR title have the correct [title format](https://github.com/amplitude/experiment-ruby-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
- Does your PR have a breaking change?: No

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core flag targeting semantics when a property is an array/JSON array string, which can alter which users qualify for segments. Also tightens `coerce_string_array` parsing behavior, potentially changing outcomes for previously mis-coerced scalar values.
> 
> **Overview**
> The evaluation engine now treats multi-valued properties (native arrays or JSON array strings) as **element-wise** inputs for *non-set* operators like `is`, `contains`, and comparisons, matching if **any** element satisfies the operator (via new `match_strings_non_set`).
> 
> `coerce_string_array` is tightened to only parse JSON when the string looks like an array (starts with `'['`) and to return `nil` for non-array/malformed JSON instead of coercing scalars into single-element arrays, reducing accidental set-operator matches. Tests are expanded with new unit coverage and additional integration cases, plus the integration spec caches the flags URI and updates the deployment key.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c73b5c6c0db9b0b50f1ced2cc8e1d2bc4de82393. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->