### PR TITLE
fix: include experiment key on local-eval exposure events

### DIFF
--- a/lib/experiment/local/exposure/exposure_service.rb
+++ b/lib/experiment/local/exposure/exposure_service.rb
@@ -47,6 +47,8 @@ module AmplitudeExperiment
         elsif variant.value
           event_properties['[Experiment] Variant'] = variant.value
         end
+        experiment_key = variant.metadata ? variant.metadata['experimentKey'] : nil
+        event_properties['[Experiment] Experiment Key'] = experiment_key if experiment_key
         event_properties['metadata'] = variant.metadata if variant.metadata
 
         # Build event.

--- a/spec/experiment/local/exposure/exposure_service_spec.rb
+++ b/spec/experiment/local/exposure/exposure_service_spec.rb
@@ -97,6 +97,17 @@ describe AmplitudeExperiment::ExposureService do
         value: 'on'
       )
       empty_variant = AmplitudeExperiment::Variant.new
+      with_experiment_key = AmplitudeExperiment::Variant.new(
+        key: 'treatment',
+        value: 'treatment',
+        metadata: {
+          'segmentName' => 'All Other Users',
+          'flagType' => 'experiment',
+          'flagVersion' => 10,
+          'default' => false,
+          'experimentKey' => 'exp-1'
+        }
+      )
       results = {
         'basic' => basic,
         'different_value' => different_value,
@@ -105,13 +116,14 @@ describe AmplitudeExperiment::ExposureService do
         'holdout' => holdout,
         'partial_metadata' => partial_metadata,
         'empty_metadata' => empty_metadata,
-        'empty_variant' => empty_variant
+        'empty_variant' => empty_variant,
+        'with_experiment_key' => with_experiment_key
       }
       exposure = AmplitudeExperiment::Exposure.new(user, results)
       events = AmplitudeExperiment::ExposureService.to_exposure_events(exposure, AmplitudeExperiment::DAY_MILLIS)
       # Should exclude default (default=true) only
-      # basic, different_value, mutex, holdout, partial_metadata, empty_metadata, empty_variant = 7 events
-      expect(events.length).to eq(7)
+      # basic, different_value, mutex, holdout, partial_metadata, empty_metadata, empty_variant, with_experiment_key = 8 events
+      expect(events.length).to eq(8)
 
       events.each do |event|
         expect(event.event_type).to eq('[Experiment] Exposure')
@@ -129,6 +141,13 @@ describe AmplitudeExperiment::ExposureService do
           expect(event.event_properties['[Experiment] Variant']).to eq(variant.value)
         end
         expect(event.event_properties['metadata']).to eq(variant.metadata) if variant.metadata
+
+        # Validate experiment key is lifted to top-level event property when present
+        if flag_key == 'with_experiment_key'
+          expect(event.event_properties['[Experiment] Experiment Key']).to eq('exp-1')
+        else
+          expect(event.event_properties).not_to have_key('[Experiment] Experiment Key')
+        end
 
         # Validate user properties
         flag_type = variant.metadata ? variant.metadata['flagType'] : nil


### PR DESCRIPTION
## Summary

- Local evaluation exposure events from `ExposureService.to_exposure_events` carried `experimentKey` only inside the `metadata` blob — the top-level event property `[Experiment] Experiment Key` was never set, so custom reports keying off it saw no value for local-eval customers.
- Fix: when `variant.metadata['experimentKey']` is present, set `event_properties['[Experiment] Experiment Key']`. Additive and backwards-compatible — `metadata`, `[Experiment] Flag Key`, `[Experiment] Variant`, user properties, and `insert_id` are unchanged.
- Mirrors [amplitude/experiment-node-server#83](https://github.com/amplitude/experiment-node-server/pull/83).

## Test plan

- [x] Added `with_experiment_key` fixture to `ExposureService` spec. Asserts `[Experiment] Experiment Key` equals `'exp-1'` for that flag and is absent for the others.
- [x] Updated event count expectation accordingly.
- [x] `bundle exec rspec spec/experiment/local/exposure/exposure_service_spec.rb` — 3 examples, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, additive analytics change that only adds a new event property when `variant.metadata['experimentKey']` is present and expands test coverage accordingly.
> 
> **Overview**
> Local-eval exposure events now copy `variant.metadata['experimentKey']` into a dedicated top-level event property, `[Experiment] Experiment Key`, instead of leaving it only inside the `metadata` blob.
> 
> Specs add a `with_experiment_key` fixture and assertions that this property is present only when provided, updating the expected event count.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3ac2136a216581fb084df48295a5eacd2a2ee0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->